### PR TITLE
Fixed ciMode not writing draw.io diagrams to filesystem

### DIFF
--- a/graph/MxGenerator.js
+++ b/graph/MxGenerator.js
@@ -250,9 +250,11 @@ async function generate(cmd, template) {
   let resourceNames = { answer: resources };
   let edgeMode = { answer: "On" };
   let actionChoice = {};
-  console.log("Writing diagram to ./template.drawio");
+  console.log("Diagram will be written to " + cmd.outputFile);
 
   if (ciMode) {
+    const xml = renderTemplate(template);
+    fs.writeFileSync(cmd.outputFile, xml);
     return;
   }
 


### PR DESCRIPTION
ciMode for drawio does not save the file anywere, this will fix log output and filename generation